### PR TITLE
[enh]: Page Metainfo should be Serialized First

### DIFF
--- a/src/Lepiter-Store/LeContent.extension.st
+++ b/src/Lepiter-Store/LeContent.extension.st
@@ -45,11 +45,11 @@ LeContent class >> leJsonV3AttributeMapping [
 LeContent class >> leJsonV4AttributeMapping [
 
 	^ super leJsonV4AttributeMapping
-		add: (#children -> #children);
 		add: (#createEmail -> #createEmail);
 		add: (#createTime -> #createTime);
 		add: (#editEmail -> #editEmail);
 		add: (#editTime -> #editTime);
+		add: (#children -> #children);
 		yourself
 ]
 

--- a/src/Lepiter-Store/LePage.extension.st
+++ b/src/Lepiter-Store/LePage.extension.st
@@ -58,8 +58,8 @@ LePage class >> leJsonV3Name [
 LePage class >> leJsonV4AttributeMapping [
 
 	^ super leJsonV4AttributeMapping
-		add: (#type -> #pageType);
-		add: (#basicUid -> #uid);
+		addFirst: (#type -> #pageType);
+		addFirst: (#basicUid -> #uid);
 		yourself
 ]
 


### PR DESCRIPTION
When you have to read the Lepiter DB files e.g. after an error, having children serialized early makes it hard to scroll down to and pick up the page's metainfo - type, uid, email and timestamps should be serialized first, then children last