### PR TITLE
Better HTML rendering of \n and \t in text snippets

### DIFF
--- a/src/Lepiter-HTML/LeHtmlTextSnippetVisitor.class.st
+++ b/src/Lepiter-HTML/LeHtmlTextSnippetVisitor.class.st
@@ -223,7 +223,17 @@ LeHtmlTextSnippetVisitor >> visitString: aString [
 
 { #category : #generated }
 LeHtmlTextSnippetVisitor >> visitText: aText [
-	context html escape: aText content.
+	| aString |
+	aString := aText content.
+	aString size = 1
+		ifFalse: [ context html escape: aString ]
+		ifTrue: [
+	aString first = Character lf
+		ifTrue: [ context html nextPutAll: '<br>' ]
+		ifFalse: [
+	aString first = Character tab
+		ifTrue: [ context html nextPutAll: '&emsp;' ]
+		ifFalse: [ context html escape: aString ] ] ].
 	
 	exportedNodes add: aText
 ]


### PR DESCRIPTION
Rendering `\n` as `<br>` should be uncontroversial, it's the exact equivalent.

Rendering `\t` as `&emsp;` does the right thing only at the beginning of a line. For my use cases, that's just fine. There is no general equivalent of tabulation in HTML, so probably there is no better implementation than this.