### PR TITLE
Wrap exported method source code with a <pre> tag

### DIFF
--- a/src/Lepiter-HTML/LeHtmlTextSnippetAnnotationVisitor.class.st
+++ b/src/Lepiter-HTML/LeHtmlTextSnippetAnnotationVisitor.class.st
@@ -153,10 +153,13 @@ LeHtmlTextSnippetAnnotationVisitor >> visitMethodAnnotation: aMethodAnnotation [
 							ifTrue: [ 'expanded-annotation-view' ]
 							ifFalse: [ 'collapsed-annotation-view' ]}}
 		do: [ 
-			context html 
-				inlineTag: 'code'
-				attributes: #('class' '')
-				with: method sourceCode ]
+			context html
+				inlineTag: 'pre'
+				do: [
+					context html
+						inlineTag: 'code'
+						attributes: #('class' '')
+						with: method sourceCode ] ]
 ]
 
 { #category : #generated }


### PR DESCRIPTION
The `<code>` tag doesn't preserve the line structure on its own, it needs to be wrapped in an additional `<pre>`.

See
https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element