### PR TITLE
Add nesting-level CSS classes to HTML for text snippets

### DIFF
--- a/src/Lepiter-Core/LeContent.class.st
+++ b/src/Lepiter-Core/LeContent.class.st
@@ -981,6 +981,11 @@ LeContent >> moveUpSnippet: aLeSnippet [
 			true ]
 ]
 
+{ #category : #'api - accessing' }
+LeContent >> nestingLevel [
+	self subclassResponsibility
+]
+
 { #category : #'api - notifications' }
 LeContent >> notifier [
 	<return: #LeNotifier>

--- a/src/Lepiter-Core/LePage.class.st
+++ b/src/Lepiter-Core/LePage.class.st
@@ -452,6 +452,11 @@ LePage >> moveUpSnippet: aLeSnippet [
 		true ]
 ]
 
+{ #category : #'api - accessing' }
+LeContent >> nestingLevel [
+	^ 0
+]
+
 { #category : #'api - notifications' }
 LePage >> notifier [
 	^ LeNotifier new

--- a/src/Lepiter-Core/LeSnippet.class.st
+++ b/src/Lepiter-Core/LeSnippet.class.st
@@ -455,6 +455,11 @@ LeSnippet >> nextSnippetDo: aBlock ifNone: aNoneBlock [
 		ifFalse: [ aBlock value: (self parent children at: myIndex + 1) ]
 ]
 
+{ #category : #'api - accessing' }
+LeContent >> nestingLevel [
+	^ 1 + self parent nestingLevel
+]
+
 { #category : #'api - notifications' }
 LeSnippet >> notifier [
 	^ LeNotifier new

--- a/src/Lepiter-HTML/LeHtmlVisitor.class.st
+++ b/src/Lepiter-HTML/LeHtmlVisitor.class.st
@@ -173,7 +173,7 @@ LeHtmlVisitor >> visitPythonSnippet: aLePythonSnippet [
 		tag: #div
 		attributes: (self
 				classesFor: aLePythonSnippet
-				withClasses: 'snippet textual-snippet code-snippet python-snippet')
+				withClasses: 'snippet textual-snippet code-snippet python-snippet nesting-level-', (aLePythonSnippet nestingLevel printString))))
 		do: [ context html
 				tag: #pre
 				attributes: #('class' 'no_bottom_margin')

--- a/src/Lepiter-HTML/LeHtmlVisitor.class.st
+++ b/src/Lepiter-HTML/LeHtmlVisitor.class.st
@@ -197,7 +197,7 @@ LeHtmlVisitor >> visitTextSnippet: aLeTextSnippet [
 		tag: #div
 		attributes: (self
 				classesFor: aLeTextSnippet
-				withClasses: 'snippet textual-snippet text-snippet')
+				withClasses: 'snippet textual-snippet text-snippet nesting-level-', (aLeTextSnippet nestingLevel printString))
 		do: [ | visitor |
 			visitor := LeHtmlTextSnippetVisitor new
 					context: context;

--- a/src/Lepiter-HTML/LeHtmlVisitor.class.st
+++ b/src/Lepiter-HTML/LeHtmlVisitor.class.st
@@ -139,7 +139,7 @@ LeHtmlVisitor >> visitPharoSnippet: aLePharoSnippet [
 		tag: #div
 		attributes: (self
 				classesFor: aLePharoSnippet
-				withClasses: 'snippet textual-snippet code-snippet pharo-snippet')
+				withClasses: 'snippet textual-snippet code-snippet pharo-snippet nesting-level-', (aLePharoSnippet nestingLevel printString)))
 		do: [ context html
 				tag: #pre
 				attributes: #('class' 'no_bottom_margin')


### PR DESCRIPTION
Enables proper indentation via CSS

Each text snippet gets an additional class tag of the form `nesting-level-1`, nesting-level-2`, etc. It can be used in CSS to define indentation:
```
.nesting-level-2 {margin-left:1rem}
.nesting-level-3 {margin-left:2rem}
```

I am not sure this is the best way to implement such a feature. It ought to be done for all snippets, not just text snippets, but there doesn't seem to be a good place in the code for that.