### PR TITLE
Add the ability to get headers from text snippits

### DIFF
--- a/src/Lepiter-Parser/LeHeaderNode.class.st
+++ b/src/Lepiter-Parser/LeHeaderNode.class.st
@@ -28,6 +28,13 @@ LeHeaderNode >> headerLevel [
 	^ numberSigns size min: 6
 ]
 
+{ #category : #accessing }
+LeHeaderNode >> headerName [
+	^ self topParent completeSource
+		copyFrom: self startPosition + self headerLevel
+		to: self stopPosition
+]
+
 { #category : #'generated-initialize-release' }
 LeHeaderNode >> initialize [
 	super initialize.

--- a/src/Lepiter-Snippet-Text/LeTextSnippet.class.st
+++ b/src/Lepiter-Snippet-Text/LeTextSnippet.class.st
@@ -321,6 +321,11 @@ LeTextSnippet >> hasString [
 	^ self hasText
 ]
 
+{ #category : #accessing }
+LeTextSnippet >> headers [
+	^ self ast // #LeHeaderNode collect: [ :val | val headerName asString ]
+]
+
 { #category : #'api - accessing' }
 LeTextSnippet >> heading [
 	<return: #Integer or: nil>


### PR DESCRIPTION
This allows us to get all header snippits from a text snippit

this is useful in getting all headers when looking at markdown websites, and in the future could be helpful when trying to convert an external markdown page into a lepiter page.

