### PR TITLE
[Enh]: Coder "Lepiter Documentation" View

### DIFF
--- a/src/Lepiter-Extensions/Class.extension.st
+++ b/src/Lepiter-Extensions/Class.extension.st
@@ -14,3 +14,16 @@ Class >> gtLepiterCommentFor: aView [
 				savePage: aTab viewContentElement page ];
 		actionUpdateButtonTooltip: 'Update class comment'
 ]
+
+{ #category : #'*Lepiter-Extensions' }
+Class >> gtLepiterReferencesFor: aView [
+	<gtView>
+	<gtClassView>
+	
+	^ aView forward
+		title: 'Documentation';
+		tooltip: 'References from Lepiter pages';
+		priority: 50;
+		object: [ self leReferences ];
+		view: #gtItemsFor:
+]


### PR DESCRIPTION
Leverages new `leReferences` to show all Lepiter pages mentioning the class.

![Screenshot_2024-08-18_at_1 01 52_PM](https://github.com/user-attachments/assets/171d297f-038f-4fc5-9d05-929a6a27dd6a)
