### PR TITLE
Add storing the scope to be saved to disk in LePharoRewriteSnippet

### DIFF
--- a/src/Lepiter-Snippet-Pharo-Rewrites/LePharoRewriteSnippet.class.st
+++ b/src/Lepiter-Snippet-Pharo-Rewrites/LePharoRewriteSnippet.class.st
@@ -281,5 +281,7 @@ LePharoRewriteSnippet >> storeOn: aStream [
 	self search storeOn: aStream.
 	aStream nextPutAll: '; replace: '.
 	self replace storeOn: aStream.
+	aStream nextPutAll: '; scope: '.
+	self scope storeOn: aStream.
 	aStream nextPutAll: '; yourself)'
 ]


### PR DESCRIPTION

Before the scope was not stored to disk, now it can be saved and loaded from disk

![](https://pomf2.lain.la/f/fgddu3w7.png)