### PR TITLE
[Enh]: Snippet Inspect Buttons - Convert to Dropdown

### DIFF
--- a/src/Lepiter-UI-Snippet/LeSnippetViewModel.class.st
+++ b/src/Lepiter-UI-Snippet/LeSnippetViewModel.class.st
@@ -102,25 +102,22 @@ LeSnippetViewModel >> gtActionIndentFor: anAction [
 { #category : #'gt - extensions' }
 LeSnippetViewModel >> gtActionInspectSnippetFor: anAction [
 	<gtAction>
-
-	^ anAction button
-		tooltip: 'Inspect Snippet Element';
-		icon: BrGlamorousVectorIcons inspect;
-		target: LeSnippetContextMenuActionTarget uniqueInstance;
-		priority: 5;
-		action: [ :aButton :aSnippetElement | aSnippetElement phlow spawnObject: aSnippetElement ]
-]
-
-{ #category : #'gt - extensions' }
-LeSnippetViewModel >> gtActionInspectViewModelFor: anAction [
-	<gtAction>
-
-	^ anAction button
-		tooltip: 'Inspect Snippet View Model';
-		icon: BrGlamorousVectorIcons debug;
-		target: LeSnippetContextMenuActionTarget uniqueInstance;
-		priority: 6;
-		action: [ :aButton :aSnippetElement | aSnippetElement phlow spawnObject: aSnippetElement snippetViewModel ]
+	
+	^ anAction dropdown
+			tooltip: 'Inspect…';
+			icon: BrGlamorousVectorIcons inspect;
+			target: LeSnippetContextMenuActionTarget uniqueInstance;
+			priority: 5;
+			content: [ :one :aSnippetElement |
+				BrGlamorousSimpleContextMenuContent new
+					items: {
+						'Inspect Snippet' -> [ aSnippetElement phlow spawnObject: aSnippetElement snippetViewModel snippetModel ].
+						'Inspect Snippet Element' -> [ aSnippetElement phlow spawnObject: aSnippetElement ].
+						'Inspect Snippet View Model' -> [ aSnippetElement phlow spawnObject: aSnippetElement snippetViewModel ]
+					};
+					hMatchParent;
+					vMatchParent];
+			yourself.
 ]
 
 { #category : #'gt - extensions' }


### PR DESCRIPTION
In the snippet context menu, there were previously one inspect button for the element and one for the view model (with a confusing lightning bolt icon), but none for the snippet itself. This is now all replaced with one inspect button that has a dropdown to inspect all three objects mentioned above.

Here is a screencast of the new behavior:

https://github.com/user-attachments/assets/9bd9f1bc-554b-4253-b45d-c7f2af976735

